### PR TITLE
Updated SDXL command from lilypad1 to lilypad3

### DIFF
--- a/lilypad/lilypad-milkyway-examples/stable-diffusion-sdxl.md
+++ b/lilypad/lilypad-milkyway-examples/stable-diffusion-sdxl.md
@@ -29,7 +29,7 @@ Ensure you have installed all requirements [install-run-requirements.md](../lily
 To run stable diffusion use the sdxl module like so:
 
 ```
-lilypad run sdxl-pipeline:v0.9-base-lilypad1 -i Prompt='a gigantic lilypad shaped space station'
+lilypad run sdxl-pipeline:v0.9-base-lilypad3 -i Prompt='a gigantic lilypad shaped space station'
 ```
 
 The output will look like this:
@@ -67,7 +67,7 @@ See this [beginner-friendly article](https://aituts.com/stable-diffusion-seed/) 
 To change the image, you can pass in a different seed number:
 
 ```bash
-`lilypad run sdxl-pipeline:v0.9-base-lilypad1 -i Prompt='a gigantic lilypad shaped space station' -i Steps=150` 
+`lilypad run sdxl-pipeline:v0.9-base-lilypad3 -i Prompt='a gigantic lilypad shaped space station' -i Steps=150` 
 ```
 
 <figure><img src="../.gitbook/assets/sdxl_result_output2.png" alt=""><figcaption><p>Output using different seed.</p></figcaption></figure>


### PR DESCRIPTION
The command to run a SDXL job was listed as ->  run sdxl-pipeline:v0.9-base-lilypad1 -i Prompt-'' 

The command should be -> run sdxl-pipeline:v0.9-base-lilypad3 -i Prompt=''

@noryev 